### PR TITLE
chore/remove extraneous storybook deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,6 @@
         "eslint": "^8.23.0",
         "http-server": "^14.1.1",
         "lit": "^3.1.2",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
         "rimraf": "^3.0.2",
         "storybook": "^8.0.6",
         "stylelint": "^13.8.0",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,6 @@
     "eslint": "^8.23.0",
     "http-server": "^14.1.1",
     "lit": "^3.1.2",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
     "rimraf": "^3.0.2",
     "storybook": "^8.0.6",
     "stylelint": "^13.8.0",


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
#13 / #19 

## Summary of Changes
1. Don't need the react deps anymore as part of the Storybook 8 upgrade