### PR TITLE
bug/restore lineup poster margin

### DIFF
--- a/src/components/lineup-poster/lineup-poster.js
+++ b/src/components/lineup-poster/lineup-poster.js
@@ -12,7 +12,7 @@ function formatSubListItem(item, idx) {
           alt="Artist name separator"
           width="85"
           height=85"
-          class="hidden md:inline w-1/12 scale-50"
+          class="hidden m-2 md:inline w-1/12 scale-50"
         />
         ${name}
       </li>


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
#35

The margin looks off
![Screenshot 2024-05-13 at 10 46 46 AM](https://github.com/AnalogStudiosRI/www.blissfestri.com/assets/895923/82d640aa-a169-4430-8ff4-4d1fde6e3a12)

## Summary of Changes
1. Restored original margin
![Screenshot 2024-05-13 at 10 46 51 AM](https://github.com/AnalogStudiosRI/www.blissfestri.com/assets/895923/bd0ac806-3b49-42f9-98b2-366014618761)