### PR TITLE
enhancement/more graceful console output for non-cloudinary enabled local dev

### DIFF
--- a/src/services/cloudinary-service.js
+++ b/src/services/cloudinary-service.js
@@ -2,6 +2,7 @@
 import * as cloudinary from 'cloudinary';
 
 const MAX_RESULTS = 500; // doubt we'll ever hit this limit...
+const { CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY, CLOUDINARY_API_SECRET } = process.env;
 
 cloudinary.config({
   cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
@@ -12,6 +13,11 @@ cloudinary.config({
 // https://cloudinary.com/documentation/admin_api#get_resources_by_asset_folder
 async function getAssetsByFolder(folderName) {
   let assets = [];
+
+  if (!CLOUDINARY_CLOUD_NAME && !CLOUDINARY_API_KEY && !CLOUDINARY_API_SECRET) {
+    console.warn('**Cloudinary credentials not detected.**');
+    return assets;
+  }
 
   try {
     const [images, videos] = await Promise.all([


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
Coming out of #10 / #41 , although a `dev:env` workflow was added, and because of https://github.com/ProjectEvergreen/greenwood/issues/991, when running `npm run dev` and ugly stack trace + error is shown, which can be confusing / annoying
```sh
➜  www.blissri.com git:(main) npm run dev

> www.blissri.com@0.0.1 dev
> greenwood develop

-------------------------------------------------------
Welcome to Greenwood (v0.29.3) ♻️
-------------------------------------------------------
Initializing project config
Initializing project workspace contexts
Generating graph of workspace files...
building from local sources...
{
  e: Error: Must supply cloud_name
      at ensureOption (/Users/owenbuckley/Workspace/analogstudiosri/www.blissri.com/node_modules/cloudinary/lib/utils/ensureOption.js:19:13)
      at /Users/owenbuckley/Workspace/analogstudiosri/www.blissri.com/node_modules/cloudinary/lib/utils/index.js:1076:22
      at call_api (/Users/owenbuckley/Workspace/analogstudiosri/www.blissri.com/node_modules/cloudinary/lib/api_client/call_api.js:11:42)
      at Object.resources (/Users/owenbuckley/Workspace/analogstudiosri/www.blissri.com/node_modules/cloudinary/lib/api.js:48:10)
      at Object.resources (/Users/owenbuckley/Workspace/analogstudiosri/www.blissri.com/node_modules/cloudinary/lib/utils/index.js:1392:21)
      at getAssetsByFolder (file:///Users/owenbuckley/Workspace/analogstudiosri/www.blissri.com/src/services/cloudinary-service.js:22:25)
      at PhotoPage.connectedCallback (file:///Users/owenbuckley/Workspace/analogstudiosri/www.blissri.com/src/pages/photos/blissfest-2023.js:7:26)
      at initializeCustomElement (file:///Users/owenbuckley/Workspace/analogstudiosri/www.blissri.com/node_modules/wc-compiler/src/wcc.js:158:27)
      at async renderToString (file:///Users/owenbuckley/Workspace/analogstudiosri/www.blissri.com/node_modules/wc-compiler/src/wcc.js:168:27)
      at async executeRouteModule (file:///Users/owenbuckley/Workspace/analogstudiosri/www.blissri.com/node_modules/@greenwood/cli/src/lib/execute-route-module.js:21:24)
}
Running Greenwood with the develop command.
Started local development server at http://localhost:1984
```

## Summary of Changes
1. Gracefully warn / return early if Cloudinary credentials are not available