### PR TITLE
bug/issue 45 footer overlapping eventbrite widget when zoomed in

### DIFF
--- a/src/pages/tickets.html
+++ b/src/pages/tickets.html
@@ -60,7 +60,7 @@
 
     <div class="flex">
       <div class="flex-col lg:w-1/2">
-        <div class="mt-8 text-left md:ml-44 lg:w-4/6 lg:ml-40 xl:ml-48">
+        <div class="mt-8 text-left md:ml-44 lg:max-w-5/6 lg:ml-40 xl:ml-48">
           <h2
             class="font-primary text-primary text-2xl uppercase font-extrabold mb-2"
           >
@@ -78,7 +78,7 @@
           </p>
         </div>
     
-        <div class="mt-8 text-left md:ml-44 lg:w-5/6 lg:ml-40 xl:ml-48">
+        <div class="mt-8 text-left md:ml-44 lg:max-w-5/6 lg:ml-40 xl:ml-48">
           <h2
             class="font-primary text-primary text-2xl uppercase font-extrabold mb-2"
           >

--- a/src/pages/tickets.html
+++ b/src/pages/tickets.html
@@ -58,48 +58,54 @@
 
     <hr class="mt-4 mb-4 m-auto md:w-2/3"/>
 
-    <div class="mt-8 text-left md:ml-44 lg:w-2/5 lg:ml-44 xl:ml-52">
-      <h2
-        class="font-primary text-primary text-2xl uppercase font-extrabold mb-2"
-      >
-        <img
-          src="/assets/images/ga-ticket.webp"
-          class="block md:inline-block  w-1/4 md:w-1/5"
-          alt="General Admission ticket stub"
-          height="101"
-          width="200"
-        />
-        General Admission (&dollar;25)
-      </h2>
-      <p class="font-primary text-primary text-left md:w-3/4">
-        This tickets affords admission for one person with access to the entrance gallery, main hall, and vendors gallery.
-      </p>
-    </div>
+    <div class="flex">
+      <div class="flex-col lg:w-1/2">
+        <div class="mt-8 text-left md:ml-44 lg:w-4/6 lg:ml-40 xl:ml-48">
+          <h2
+            class="font-primary text-primary text-2xl uppercase font-extrabold mb-2"
+          >
+            <img
+              src="/assets/images/ga-ticket.webp"
+              class="block md:inline-block  w-1/4 md:w-1/5"
+              alt="General Admission ticket stub"
+              height="101"
+              width="200"
+            />
+            General Admission (&dollar;25)
+          </h2>
+          <p class="font-primary text-primary text-left md:w-3/4">
+            This tickets affords admission for one person with access to the entrance gallery, main hall, and vendors gallery.
+          </p>
+        </div>
+    
+        <div class="mt-8 text-left md:ml-44 lg:w-5/6 lg:ml-40 xl:ml-48">
+          <h2
+            class="font-primary text-primary text-2xl uppercase font-extrabold mb-2"
+          >
+            <img
+              src="/assets/images/vip-ticket.webp"
+              class="block md:inline-block w-1/4 md:w-1/5"
+              alt="VIP ticket stub"
+              height="101"
+              width="200"
+            />
+            VIP Package (&dollar;45)
+          </h2>
+          <p class="font-primary text-primary text-left md:w-3/4">
+            Includes General Admission and access to the mezzanine section and green room, a 10&percnt; off merch coupon code, and complimentary snacks and refreshments.  New perks this year include an event poster and an exclusive video / audio recording of highlights from the event.
+          </p>
+        </div>
+      </div>
 
-    <div class="mt-8 text-left md:ml-44 lg:w-2/5 lg:ml-44 xl:ml-52">
-      <h2
-        class="font-primary text-primary text-2xl uppercase font-extrabold mb-2"
-      >
-        <img
-          src="/assets/images/vip-ticket.webp"
-          class="block md:inline-block w-1/4 md:w-1/5"
-          alt="VIP ticket stub"
-          height="101"
-          width="200"
-        />
-        VIP Package (&dollar;45)
-      </h2>
-      <p class="font-primary text-primary text-left md:w-3/4">
-        Includes General Admission and access to the mezzanine section and green room, a 10&percnt; off merch coupon code, and complimentary snacks and refreshments.  New perks this year include an event poster and an exclusive video / audio recording of highlights from the event.
-      </p>
+      <div class="flex-col hidden lg:block lg:w-1/2">
+        <!-- TODO it is a known issue that for local dev the EventBrite iframe overflows on top of the footer -->
+        <!-- https://github.com/AnalogStudiosRI/www.blissri.com/issues/4 -->
+        <div
+          id="eventbrite-widget-container-902468426357"
+          class="hidden lg:block lg:w-5/6"
+        ></div>
+      </div>
     </div>
-
-    <!-- TODO it is a known issue that for local dev the EventBrite iframe overflows on top of the footer -->
-    <!-- https://github.com/AnalogStudiosRI/www.blissri.com/issues/4 -->
-    <div
-      id="eventbrite-widget-container-902468426357"
-      class="hidden lg:inline-block w-1/3 float-right -mt-72 mr-24 bg-slate-50 h-96 xl:w-2/5"
-    ></div>
   </body>
 
 </html>

--- a/src/templates/app.html
+++ b/src/templates/app.html
@@ -27,10 +27,7 @@
       <page-outlet></page-outlet>
     </main>
 
-    <div class="min-h-screen flex flex-col justify-between">
-      <section class="flex-grow"></section>
-      <bf-footer class="block mt-8 clear-both"></bf-footer>
-    </div>
+    <bf-footer class="block mt-8"></bf-footer>
   </body>
 
 </html>

--- a/src/templates/app.html
+++ b/src/templates/app.html
@@ -27,7 +27,10 @@
       <page-outlet></page-outlet>
     </main>
 
-    <bf-footer class="block mt-8"></bf-footer>
+    <div class="min-h-screen flex flex-col justify-between">
+      <section class="flex-grow"></section>
+      <bf-footer class="block mt-8 clear-both"></bf-footer>
+    </div>
   </body>
 
 </html>


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolve #45 

## Summary of Changes
1. Refactor away usage of `float` to use `flex-box` for two column layout on tickets page on >= desktop browsers

Now even at 150% zoom, the footer easily clears the EventBrite widget, and all other breakpoints looks great too now!  😮‍💨 
![Screenshot 2024-05-30 at 4 50 24 PM](https://github.com/AnalogStudiosRI/www.blissri.com/assets/895923/0cd756c9-1733-4b5c-a296-fa34870d4a98)
![Screenshot 2024-05-30 at 4 50 44 PM](https://github.com/AnalogStudiosRI/www.blissri.com/assets/895923/9575363b-a0b0-403a-a742-6f4d755bcb3e)
![Screenshot 2024-05-30 at 4 50 54 PM](https://github.com/AnalogStudiosRI/www.blissri.com/assets/895923/0c60112e-8310-4cb1-b9d7-3d6c86dbcd1a)
